### PR TITLE
feat(tekton): add B64 encoded annotation

### DIFF
--- a/.tekton/rhtap-backstage-plugins-pull-request.yaml
+++ b/.tekton/rhtap-backstage-plugins-pull-request.yaml
@@ -219,6 +219,32 @@ spec:
             workspace: git-auth
           - name: netrc
             workspace: netrc
+      - name: generate-annotations
+        params:
+          - name: ociStorage
+            value: $(params.output-image).script
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+          - name: SCRIPT_RUNNER_IMAGE
+            value: registry.redhat.io/rhel9/nodejs-20:latest
+          - name: SCRIPT
+            value: |
+              #!/bin/bash
+
+              node ./utils/generate-annotations.js
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        runAfter:
+          - prefetch-dependencies
+        taskRef:
+          params:
+            - name: name
+              value: run-script-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:c0f627069353ebd6d1ed03c8657e281eaf11be63706ea38cc53caf16cf4ffd65
+            - name: kind
+              value: task
+          resolver: bundles
       - name: build-container
         params:
           - name: IMAGE
@@ -241,17 +267,19 @@ spec:
           - name: BUILD_ARGS_FILE
             value: $(params.build-args-file)
           - name: SOURCE_ARTIFACT
-            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+            value: $(tasks.generate-annotations.results.SCRIPT_ARTIFACT)
           - name: CACHI2_ARTIFACT
             value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+          - name: ANNOTATIONS_FILE
+            value: "annotations.txt"
         runAfter:
-          - prefetch-dependencies
+          - generate-annotations
         taskRef:
           params:
             - name: name
               value: buildah-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:ff54d822edc622ac35bad58dacc06063123f9a8cbc79f73913345c7c485430c4
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:03be9d41b9617edc1436ae5a29cbd130f5101e5031d198f24c463672009754ac
             - name: kind
               value: task
           resolver: bundles

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,3 @@
+# Utils
+
+Utility scripts used for various purposes.

--- a/utils/generate-annotations.js
+++ b/utils/generate-annotations.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// Find all package.json files recursively
+function findPackageJsonFiles(dir, ignoreDirs = ['node_modules', '.git']) {
+  let results = [];
+  const items = fs.readdirSync(dir);
+
+  for (const item of items) {
+    if (ignoreDirs.includes(item)) continue;
+
+    const itemPath = path.join(dir, item);
+    const stat = fs.statSync(itemPath);
+
+    if (stat.isDirectory()) {
+      results = results.concat(findPackageJsonFiles(itemPath, ignoreDirs));
+    } else if (stat.isFile() && item === 'package.json') {
+      results.push(itemPath);
+    }
+  }
+
+  return results;
+}
+
+// Transform a single package.json
+function transformPackageJson(inputJson) {
+  if (!inputJson.name || !inputJson.version || !inputJson.backstage) return null;
+
+  const dynamicKey = `${inputJson.name.replace('@', '').replace('/', '-')}-dynamic`;
+
+  return {
+    [dynamicKey]: {
+      name: inputJson.name,
+      version: inputJson.version,
+      backstage: inputJson.backstage,
+      homepage: inputJson.homepage || null,
+      repository: inputJson.repository || null,
+      license: inputJson.license || null,
+      author: inputJson.author || null,
+      bugs: inputJson.bugs || null,
+      keywords: inputJson.keywords || []
+    }
+  };
+}
+
+// Main function to process plugins directory
+function main() {
+  const pluginsDir = './plugins';
+  const outputFilePath = './temp.json';
+
+  try {
+    // Find all package.json files in plugins dir
+    const packageJsonFiles = findPackageJsonFiles(pluginsDir);
+    console.log(`Found ${packageJsonFiles.length} package.json files in ${pluginsDir}`);
+
+    // Process each file and combine results
+    const results = [];
+    let processedCount = 0;
+
+    for (const filePath of packageJsonFiles) {
+      try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        const packageJson = JSON.parse(content);
+        const transformedObject = transformPackageJson(packageJson);
+
+        if (transformedObject) {
+          const key = Object.keys(transformedObject)[0];
+          results.push({ [key]: transformedObject[key] });
+          processedCount++;
+        }
+      } catch (err) {
+        console.error(`Error processing ${filePath}: ${err.message}`);
+      }
+    }
+
+    // Write the combined result
+    fs.writeFileSync(outputFilePath, JSON.stringify(results, null, null), 'utf8');
+    console.log(`Successfully processed ${processedCount} plugins and saved to ${outputFilePath}`);
+
+    // Base64 encode the contents, print it.
+    const jsonContent = fs.readFileSync(outputFilePath);
+    const hash = jsonContent.toString('base64');
+    // Delete temp json file
+    fs.unlinkSync(outputFilePath);
+    fs.writeFileSync('annotations.txt', `io.backstage.dynamic-packages=${hash}`);
+    // Output so it gets grabbed by next task.
+    console.log(hash);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}
+// Run the script
+main();


### PR DESCRIPTION
# Feature:
- Create a script that generates the `index.json` file similar to how `@janus-idp/cli` does and generate a base64 has from it.
- Create a Tekton task that generates the `io.backstage.dynamic-packages` annotation with the value being the base64 hash generated from the script. Export it to a file
- Use that file for setting the annotations